### PR TITLE
Unify get events

### DIFF
--- a/src/main/kotlin/no/nav/delta/event/Routes.kt
+++ b/src/main/kotlin/no/nav/delta/event/Routes.kt
@@ -56,7 +56,7 @@ fun Route.eventApi(database: DatabaseInterface) {
                 }
             }
         }
-        route("/admin") {
+        route("/admin/event") {
             put {
                 val createEvent = call.receive(CreateEvent::class)
                 val ownerEmail = call.principalEmail()

--- a/src/main/kotlin/no/nav/delta/event/Routes.kt
+++ b/src/main/kotlin/no/nav/delta/event/Routes.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.flatMap
 import arrow.core.getOrElse
 import arrow.core.left
+import arrow.core.none
 import arrow.core.right
 import arrow.core.some
 import io.ktor.http.HttpStatusCode
@@ -20,39 +21,42 @@ import kotlin.reflect.jvm.jvmName
 import no.nav.delta.plugins.DatabaseInterface
 
 fun Route.eventApi(database: DatabaseInterface) {
-    route("/event") {
-        get {
-            val onlyFuture = call.parameters["onlyFuture"]?.toBoolean() ?: false
-            val onlyPublic = call.parameters["onlyPublic"]?.toBoolean() ?: false
-            call.respond(database.getEvents(onlyFuture, onlyPublic))
-        }
-        route("/{id}") {
-            get {
-                val id =
-                    call.getUuidFromPath().getOrElse {
-                        return@get it.left().unwrapAndRespond(call)
-                    }
-
-                database
-                    .getEvent(id.toString())
-                    .flatMap { event ->
-                        database.getParticipants(id.toString()).map { participants ->
-                            EventWithParticipants(event, participants)
-                        }
-                    }
-                    .unwrapAndRespond(call)
-            }
-        }
-    }
-
     authenticate("jwt") {
-        route("/admin/event") {
+        route("/event") {
             get {
-                val ownerEmail = call.principalEmail()
+                val email = call.principalEmail()
 
-                call.respond(database.getEvents(byOwner = ownerEmail.some()))
+                val onlyFuture = call.parameters["onlyFuture"]?.toBoolean() ?: false
+
+                val onlyMine = call.parameters["onlyMine"]?.toBoolean() ?: false
+                val ownedBy = if (onlyMine) email.some() else none()
+
+                val onlyJoined = call.parameters["onlyJoined"]?.toBoolean() ?: false
+                val joinedBy = if (onlyJoined) email.some() else none()
+
+                val onlyPublic = !onlyMine && !onlyJoined
+
+                call.respond(database.getEvents(onlyFuture, onlyPublic, ownedBy, joinedBy))
             }
+            route("/{id}") {
+                get {
+                    val id =
+                        call.getUuidFromPath().getOrElse {
+                            return@get it.left().unwrapAndRespond(call)
+                        }
 
+                    database
+                        .getEvent(id.toString())
+                        .flatMap { event ->
+                            database.getParticipants(id.toString()).map { participants ->
+                                EventWithParticipants(event, participants)
+                            }
+                        }
+                        .unwrapAndRespond(call)
+                }
+            }
+        }
+        route("/admin") {
             put {
                 val createEvent = call.receive(CreateEvent::class)
                 val ownerEmail = call.principalEmail()
@@ -117,14 +121,7 @@ fun Route.eventApi(database: DatabaseInterface) {
                 }
             }
         }
-
         route("/user/event") {
-            get {
-                val principal = call.principal<JWTPrincipal>()!!
-                val email = principal["preferred_username"]!!.lowercase()
-
-                call.respond(database.getEvents(joinedBy = email.some()))
-            }
             route("/{id}") {
                 post {
                     val id =

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -8,20 +8,6 @@ servers:
   - url: "http://delta-backend"
 paths:
   /admin/event:
-    get:
-      tags:
-        - admin
-      description: "Get all events created by me"
-      operationId: getMyEvents
-      responses:
-        "200":
-          description: "All my events"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Event"
     put:
       tags:
         - admin
@@ -103,21 +89,6 @@ paths:
       responses:
         "200":
           description: "Participant removed"
-  /user/event:
-    get:
-      tags:
-        - user
-      description: "Get all joined events"
-      operationId: getJoinedEvents
-      responses:
-        "200":
-          description: "All joined events"
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Event"
   /user/event/{id}:
     post:
       tags:
@@ -156,15 +127,21 @@ paths:
       description: "Get future events"
       operationId: getFutureEvents
       parameters:
-        - name: onlyPublic
-          in: query
-          description: "Public events only"
+        - in: query
+          name: onlyFuture
+          description: "Future events only"
           required: false
           schema:
             type: boolean
-        - name: onlyFuture
-          in: query
-          description: "Future events only"
+        - in: query
+          name: onlyMine
+          description: "Only my events"
+          required: false
+          schema:
+            type: boolean
+        - in: query
+          name: onlyJoined
+          description: "Only joined events"
           required: false
           schema:
             type: boolean


### PR DESCRIPTION
All retrieval of multiple events are now done using the /event endpoint. Filters can be applied using query parameters (check out the swagger docs).