### PR TITLE
Send out updates to events in separate threads to improve resiliency

### DIFF
--- a/src/main/kotlin/no/nav/delta/event/Routes.kt
+++ b/src/main/kotlin/no/nav/delta/event/Routes.kt
@@ -147,8 +147,8 @@ fun Route.eventApi(database: DatabaseInterface, cloudClient: CloudClient) {
                         database
                             .getAllParticipantsAndCalendarEventIds(newEvent.id.toString())
                             .map { pairs ->
-                                {
-                                    pairs.map { (participant, calendarEventId) ->
+                                pairs.map { (participant, calendarEventId) ->
+                                    {
                                         cloudClient.sendUpdateOrCreationNotification(
                                             newEvent,
                                             database,
@@ -156,16 +156,15 @@ fun Route.eventApi(database: DatabaseInterface, cloudClient: CloudClient) {
                                             calendarEventId.getOrNull(),
                                         )
                                     }
-                                    Unit
                                 }
                             }
-                            .getOrElse { {} }
+                            .getOrElse { listOf() }
 
                     database
                         .updateEvent(newEvent)
                         .flatMap { event -> database.getFullEvent(event.id.toString()) }
                         .map {
-                            Thread(sendUpdateFuture).start()
+                            sendUpdateFuture.forEach { future -> Thread(future).start() }
                             it
                         }
                         .unwrapAndRespond(call)


### PR DESCRIPTION
In case one of the updates fails, the rest will still *try* to finish. This could result in extra load in case the azure service is unavailable, but i think it is worth it.